### PR TITLE
Fix vendor name and add support for EXCALIBUR G770

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Provides per-zone RGB keyboard control, fan speed monitoring, and power plan man
 | EXCALIBUR G750 | any | `false` | Supported |
 | EXCALIBUR G900 | CP131 | `false` | Supported |
 | EXCALIBUR G870 | CQ141 | `true` | Supported — rainbow mode confirmed |
+| EXCALIBUR G770 | CP221 | `true` | Supported |
 
 If your model is not listed, the driver will still load and function but will emit a warning in `dmesg`. See [Adding New Models](#adding-new-models).
 

--- a/excalibur.c
+++ b/excalibur.c
@@ -186,7 +186,7 @@ static const struct dmi_system_id excalibur_dmi_list[] = {
 		.callback    = dmi_matched,
 		.ident       = "EXCALIBUR G650",
 		.matches     = {
-			DMI_MATCH(DMI_SYS_VENDOR,   "EXCALIBUR BILGISAYAR SISTEMLERI"),
+			DMI_MATCH(DMI_SYS_VENDOR,   "CASPER BILGISAYAR SISTEMLERI"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "EXCALIBUR G650"),
 		},
 		.driver_data = (void *)false,
@@ -195,7 +195,7 @@ static const struct dmi_system_id excalibur_dmi_list[] = {
 		.callback    = dmi_matched,
 		.ident       = "EXCALIBUR G750",
 		.matches     = {
-			DMI_MATCH(DMI_SYS_VENDOR,   "EXCALIBUR BILGISAYAR SISTEMLERI"),
+			DMI_MATCH(DMI_SYS_VENDOR,   "CASPER BILGISAYAR SISTEMLERI"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "EXCALIBUR G750"),
 		},
 		.driver_data = (void *)false,
@@ -204,7 +204,7 @@ static const struct dmi_system_id excalibur_dmi_list[] = {
 		.callback    = dmi_matched,
 		.ident       = "EXCALIBUR G670",
 		.matches     = {
-			DMI_MATCH(DMI_SYS_VENDOR,   "EXCALIBUR BILGISAYAR SISTEMLERI"),
+			DMI_MATCH(DMI_SYS_VENDOR,   "CASPER BILGISAYAR SISTEMLERI"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "EXCALIBUR G670"),
 		},
 		.driver_data = (void *)false,
@@ -213,7 +213,7 @@ static const struct dmi_system_id excalibur_dmi_list[] = {
 		.callback    = dmi_matched,
 		.ident       = "EXCALIBUR G900",
 		.matches     = {
-			DMI_MATCH(DMI_SYS_VENDOR,   "EXCALIBUR BILGISAYAR SISTEMLERI"),
+			DMI_MATCH(DMI_SYS_VENDOR,   "CASPER BILGISAYAR SISTEMLERI"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "EXCALIBUR G900"),
 			DMI_MATCH(DMI_BIOS_VERSION, "CP131"),
 		},
@@ -223,7 +223,7 @@ static const struct dmi_system_id excalibur_dmi_list[] = {
 		.callback    = dmi_matched,
 		.ident       = "EXCALIBUR G870",
 		.matches     = {
-			DMI_MATCH(DMI_SYS_VENDOR,   "EXCALIBUR BILGISAYAR SISTEMLERI"),
+			DMI_MATCH(DMI_SYS_VENDOR,   "CASPER BILGISAYAR SISTEMLERI"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "EXCALIBUR G870"),
 			DMI_MATCH(DMI_BIOS_VERSION, "CQ141"),
 		},

--- a/excalibur.c
+++ b/excalibur.c
@@ -229,6 +229,16 @@ static const struct dmi_system_id excalibur_dmi_list[] = {
 		},
 		.driver_data = (void *)true,
 	},
+	{
+		.callback    = dmi_matched,
+		.ident       = "EXCALIBUR G770",
+		.matches     = {
+			DMI_MATCH(DMI_SYS_VENDOR,   "CASPER BILGISAYAR SISTEMLERI"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "EXCALIBUR G770"),
+			DMI_MATCH(DMI_BIOS_VERSION, "CP221"),
+		},
+		.driver_data = (void *)true,
+	},
 	{ }
 };
 


### PR DESCRIPTION
Support for EXCALIBUR G770 was mentioned in #2. This PR additionally corrects the vendor name to be the proper one.