### PR TITLE
add support for pardus in the installer script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ detect_distro() {
             PKG_INSTALL="pacman -S --noconfirm"
             HEADERS_PKG="linux-headers"
             ;;
-        ubuntu|debian|linuxmint|pop)
+        ubuntu|debian|linuxmint|pop|pardus)
             INITRAMFS_CMD="update-initramfs -u"
             PKG_INSTALL="apt-get install -y"
             HEADERS_PKG="linux-headers-$(uname -r)"


### PR DESCRIPTION
Pardus is based on Debian, so it's safe to add it to the same array as Debian itself.

Without this, we get the following output at the beginning:
```
yachiyo@runami-g770:~/excalibur$ sudo ./install.sh 
[sudo] password for yachiyo: 
  ⚠  Unrecognised distro 'pardus'. initramfs update will be skipped.
  ✔  Kernel was built with gcc — using gcc for module build
```